### PR TITLE
Check for skipped file before processing content

### DIFF
--- a/lib/organization_gem_dependencies/cli.rb
+++ b/lib/organization_gem_dependencies/cli.rb
@@ -36,12 +36,15 @@ module OrganizationGemDependencies
       gems = {}
 
       remote_search(github, github_organization, GEMFILE_LOCK_SEARCH_TERM) do |gemfile_lock|
-        content = Bundler::LockfileParser.new(remote_file(github, gemfile_lock))
+        content = remote_file(github, gemfile_lock)
+        next unless content
+        content = Bundler::LockfileParser.new(content)
         merge!(gems, process_gemfile(content, "#{gemfile_lock.repository.name}/#{gemfile_lock.path}"))
       end
 
       remote_search(github, github_organization, GEMSPEC_SEARCH_TERM) do |gemspec|
         content = remote_file(github, gemspec)
+        next unless content
         merge!(gems, process_gemspec(content, "#{gemspec.repository.name}/#{gemspec.path}"))
       end
 


### PR DESCRIPTION
This is what happens when you don’t write tests :-(

The error was:

```
Skipping archive/afss/Gemfile.lock
bundler: failed to load command: bin/organization_gem_dependencies (bin/organization_gem_dependencies)
NoMethodError: undefined method `match' for nil:NilClass
  /Users/magne/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/bundler/lockfile_parser.rb:69:in `initialize'
  /Users/magne/src/organization_gem_dependencies/lib/organization_gem_dependencies/cli.rb:39:in `new'
  /Users/magne/src/organization_gem_dependencies/lib/organization_gem_dependencies/cli.rb:39:in `block in run'
  /Users/magne/src/organization_gem_dependencies/lib/organization_gem_dependencies/cli.rb:122:in `block in remote_search'
  /Users/magne/src/organization_gem_dependencies/lib/organization_gem_dependencies/cli.rb:121:in `each'
  /Users/magne/src/organization_gem_dependencies/lib/organization_gem_dependencies/cli.rb:121:in `remote_search'
  /Users/magne/src/organization_gem_dependencies/lib/organization_gem_dependencies/cli.rb:38:in `run'
  bin/organization_gem_dependencies:5:in `<top (required)>'
```