### PR TITLE
Fix uninitialized constant Bundler::LockfileParser

### DIFF
--- a/lib/usedby/cli.rb
+++ b/lib/usedby/cli.rb
@@ -5,6 +5,7 @@ require 'io/console'
 require 'json'
 require 'optparse'
 
+require 'bundler'
 require 'octokit'
 
 require 'usedby/version_ranges_intersection'


### PR DESCRIPTION
I'm not quite sure how this worked before, but it works again for me by explicitly requiring `bundler`.